### PR TITLE
Fix register/login token flow

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -25,12 +25,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }
 
   const signUp = async (email: string, passwd: string) => {
-    const res = await register({ email, passwd })
-    const tokenValue = res.data.data?.token
-    setToken(tokenValue)
-    setUserEmail(email)
-    localStorage.setItem('token', tokenValue)
-    localStorage.setItem('email', email)
+    await register({ email, passwd })
+    // No establecer token ni email en el registro para obligar al
+    // usuario a iniciar sesión posteriormente.
   }
 
   const signOut = () => {

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -10,7 +10,8 @@ export default function Register() {
   const submit = async (e: React.FormEvent) => {
     e.preventDefault()
     await signUp(email, password)
-    nav('/')
+    // Redirigir al login tras registro exitoso
+    nav('/login')
   }
   return (
     <form onSubmit={submit} className="max-w-sm mx-auto p-4">


### PR DESCRIPTION
## Summary
- redirect to login after successful register
- store token only on login

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68536e148a748330af51be8250934540