### PR TITLE
Implement configurable API URL and month filters

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const api = axios.create({
-  baseURL: 'http://localhost:8000',
+  baseURL: import.meta.env.VITE_API_URL ?? 'http://198.211.105.95:8080',
 })
 
 api.interceptors.request.use(config => {

--- a/src/pages/CategoryDetail.tsx
+++ b/src/pages/CategoryDetail.tsx
@@ -3,6 +3,7 @@ import { useParams, useSearchParams } from 'react-router-dom'
 import { useExpenseDetails } from '../hooks/useExpensesSummary'
 import { createExpense, deleteExpense } from '../api/expenses'
 import type { Expense } from '../types/expense'
+import { formatCurrency } from '../utils/formatters'
 
 export default function CategoryDetail() {
   const { id } = useParams<{ id: string }>()
@@ -52,7 +53,7 @@ export default function CategoryDetail() {
       <ul className="space-y-2">
         {expenses.map(exp => (
           <li key={exp.id} className="border p-2 flex justify-between">
-            <span>S/. {exp.amount}</span>
+            <span>{formatCurrency(exp.amount)}</span>
             <button
               onClick={() => removeExpense(exp.id)}
               className="text-red-600 hover:underline"

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,12 +1,13 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useExpensesSummary } from '../hooks/useExpensesSummary'
 import type { ExpenseSummary } from '../types/expenseSummary'
+import { formatCurrency } from '../utils/formatters'
 
 const Dashboard: React.FC = () => {
   const now = new Date()
-  const year = now.getFullYear()
-  const month = now.getMonth() + 1
+  const [year, setYear] = useState(now.getFullYear())
+  const [month, setMonth] = useState(now.getMonth() + 1)
   const { data, isLoading, isError } = useExpensesSummary(year, month)
   const summaries: ExpenseSummary[] = data?.data ?? []
 
@@ -16,6 +17,30 @@ const Dashboard: React.FC = () => {
   return (
     <div>
       <h1 className="text-xl mb-4">Resumen de {month}/{year}</h1>
+      <div className="mb-4 flex gap-2">
+        <select
+          value={month}
+          onChange={e => setMonth(Number(e.target.value))}
+          className="border rounded px-2 py-1"
+        >
+          {Array.from({ length: 12 }, (_, i) => i + 1).map(m => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+        <select
+          value={year}
+          onChange={e => setYear(Number(e.target.value))}
+          className="border rounded px-2 py-1"
+        >
+          {Array.from({ length: 5 }, (_, i) => now.getFullYear() - 2 + i).map(y => (
+            <option key={y} value={y}>
+              {y}
+            </option>
+          ))}
+        </select>
+      </div>
       {summaries.length > 0 ? (
         <div className="grid grid-cols-2 gap-4">
           {summaries.map(item => (
@@ -25,7 +50,7 @@ const Dashboard: React.FC = () => {
               className="block border rounded p-4 hover:shadow"
             >
               <h2 className="font-semibold">{item.expenseCategory.name}</h2>
-              <div className="mt-2 text-sm text-gray-500">Total: S/. {item.amount}</div>
+              <div className="mt-2 text-sm text-gray-500">Total: {formatCurrency(item.amount)}</div>
             </Link>
           ))}
         </div>

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,2 +1,2 @@
 export const formatCurrency = (value: number) =>
-  '$' + value.toFixed(2)
+  `S/. ${value.toFixed(2)}`


### PR DESCRIPTION
## Summary
- parameterize backend URL via `VITE_API_URL`
- add month and year selectors in Dashboard
- improve currency display with a formatter
- use currency formatter in category details and summary

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6853963d885c83308384c4de09f0164c