### PR TITLE
Implement features for authentication and goals

### DIFF
--- a/src/api/expenses.ts
+++ b/src/api/expenses.ts
@@ -1,28 +1,9 @@
 // services/expenses.ts
-import axios from 'axios';
-import type { ExpenseCategoryCreate } from '../types/expenseCategory';
+import type { ExpenseCategoryCreate } from '../types/expenseCategory'
+import { api } from './client'
 
-const API_BASE_URL = 'http://localhost:8000';
-// const API_BASE_URL = 'http://198.211.105.95:8080';
-
-// Instancia base sin token (para login/register)
-export const api = axios.create({
-  baseURL: API_BASE_URL
-});
-
-// Instancia con interceptor para rutas privadas
-export const privateApi = axios.create({
-  baseURL: API_BASE_URL
-});
-
-// Interceptor: agrega el token antes de cada petición
-privateApi.interceptors.request.use((config) => {
-  const token = localStorage.getItem('token'); // ← Obtiene el token actualizado
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
-  }
-  return config;
-});
+// Reutilizamos la instancia configurada con el interceptor
+const privateApi = api
 
 // Funciones de expenses (usarán privateApi)
 export const getExpensesCategory = () =>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -16,19 +16,27 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [userEmail, setUserEmail] = useState<string | null>(localStorage.getItem('email'))
 
   const signIn = async (email: string, passwd: string) => {
-    const res = await login({ email, passwd })
-    setToken(res.data.result.token)
-    setUserEmail(email)
-    localStorage.setItem('token', res.data.result.token)
-    localStorage.setItem('email', email)
-    console.log('Usuario autenticado:', res.data.result.token)
+    try {
+      const res = await login({ email, passwd })
+      setToken(res.data.result.token)
+      setUserEmail(email)
+      localStorage.setItem('token', res.data.result.token)
+      localStorage.setItem('email', email)
+    } catch (err) {
+      throw err
+    }
   }
+
   const signUp = async (email: string, passwd: string) => {
-    const res = await register({ email, passwd })
-    setToken(res.data.token)
-    setUserEmail(email)
-    localStorage.setItem('token', res.data.token)
-    localStorage.setItem('email', email)
+    try {
+      const res = await register({ email, passwd })
+      setToken(res.data.token)
+      setUserEmail(email)
+      localStorage.setItem('token', res.data.token)
+      localStorage.setItem('email', email)
+    } catch (err) {
+      throw err
+    }
   }
   const signOut = () => {
     setToken(null)

--- a/src/hooks/useExpensesDetail.ts
+++ b/src/hooks/useExpensesDetail.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query'
+import { getDetails } from '../api/expenses'
+
+export const useExpensesDetail = (year: number, month: number, categoryId: number) =>
+  useQuery({
+    queryKey: ['expensesDetail', year, month, categoryId],
+    queryFn: () => getDetails(year, month, categoryId),
+    enabled: Boolean(year && month && categoryId)
+  })

--- a/src/hooks/useGoals.ts
+++ b/src/hooks/useGoals.ts
@@ -1,0 +1,25 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getGoals, createGoal, updateGoal } from '../api/goals'
+import type { Goal } from '../types/goal'
+
+export const useGoals = () =>
+  useQuery({
+    queryKey: ['goals'],
+    queryFn: getGoals
+  })
+
+export const useCreateGoal = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: Goal) => createGoal(data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['goals'] })
+  })
+}
+
+export const useUpdateGoal = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: Partial<Goal> }) => updateGoal(id, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['goals'] })
+  })
+}

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -7,17 +7,38 @@ export default function Login() {
   const nav = useNavigate()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
   const submit = async (e: React.FormEvent) => {
     e.preventDefault()
-    await signIn(email, password)
-    nav('/')
+    try {
+      await signIn(email, password)
+      nav('/')
+    } catch (err: any) {
+      setError(err.response?.data?.message || 'Credenciales inválidas')
+    }
   }
+
   return (
-    <form onSubmit={submit} className="max-w-sm mx-auto p-4">
+    <form onSubmit={submit} className="max-w-sm mx-auto p-4 space-y-2">
       <h1 className="text-2xl mb-4">Login</h1>
-      <input type="email" value={email} onChange={e=>setEmail(e.target.value)} placeholder="Email" className="block mb-2 w-full rounded border px-2 py-1"/>
-      <input type="password" value={password} onChange={e=>setPassword(e.target.value)} placeholder="Password" className="block mb-4 w-full rounded border px-2 py-1"/>
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      <input
+        type="email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+        placeholder="Email"
+        className="block mb-2 w-full rounded border px-2 py-1"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+        placeholder="Password"
+        className="block mb-4 w-full rounded border px-2 py-1"
+      />
       <button type="submit" className="btn btn-primary w-full">Entrar</button>
     </form>
   )
 }
+

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -7,16 +7,40 @@ export default function Register() {
   const nav = useNavigate()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
   const submit = async (e: React.FormEvent) => {
     e.preventDefault()
-    await signUp(email, password)
-    nav('/')
+    if (password.length < 12) {
+      setError('La contraseña debe tener al menos 12 caracteres')
+      return
+    }
+    try {
+      await signUp(email, password)
+      nav('/')
+    } catch (err: any) {
+      setError(err.response?.data?.message || 'Error de registro')
+    }
   }
+
   return (
-    <form onSubmit={submit} className="max-w-sm mx-auto p-4">
+    <form onSubmit={submit} className="max-w-sm mx-auto p-4 space-y-2">
       <h1 className="text-2xl mb-4">Registro</h1>
-      <input type="email" value={email} onChange={e=>setEmail(e.target.value)} placeholder="Email" className="block mb-2 w-full rounded border px-2 py-1"/>
-      <input type="password" value={password} onChange={e=>setPassword(e.target.value)} placeholder="Password" className="block mb-4 w-full rounded border px-2 py-1"/>
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      <input
+        type="email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+        placeholder="Email"
+        className="block mb-2 w-full rounded border px-2 py-1"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+        placeholder="Password"
+        className="block mb-4 w-full rounded border px-2 py-1"
+      />
       <button type="submit" className="btn btn-primary w-full">Crear cuenta</button>
     </form>
   )

--- a/src/pages/CategoryDetail.tsx
+++ b/src/pages/CategoryDetail.tsx
@@ -1,4 +1,39 @@
 import React from 'react'
-export default function PLACEHOLDER() {
-  return <div className="p-4 text-center">Página PLACEHOLDER</div>
+import { useParams, useSearchParams } from 'react-router-dom'
+import { useDeleteExpense } from '../hooks/useExpensesSummary'
+import { useExpensesDetail } from '../hooks/useExpensesDetail'
+
+export default function CategoryDetail() {
+  const { id } = useParams<{ id: string }>()
+  const [search] = useSearchParams()
+  const year = Number(search.get('year'))
+  const month = Number(search.get('month'))
+  const { data, isLoading, isError, refetch } = useExpensesDetail(year, month, Number(id))
+  const deleteMutation = useDeleteExpense()
+  const expenses = data?.data ?? []
+
+  const handleDelete = async (expId: number) => {
+    if (!window.confirm('¿Eliminar gasto?')) return
+    await deleteMutation.mutateAsync(expId)
+    refetch()
+  }
+
+  if (isLoading) return <div className="p-4">Cargando...</div>
+  if (isError) return <div className="p-4 text-red-500">Error al cargar</div>
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Detalles</h1>
+      {expenses.length === 0 && <p>No hay datos</p>}
+      {expenses.map((exp: any) => (
+        <div key={exp.id} className="border p-2 rounded flex justify-between">
+          <div>
+            <p className="font-medium">{exp.expenseCategory.name}</p>
+            <p className="text-sm text-gray-500">{exp.date} - {exp.amount}</p>
+          </div>
+          <button onClick={() => handleDelete(exp.id)} className="text-red-600">Eliminar</button>
+        </div>
+      ))}
+    </div>
+  )
 }

--- a/src/pages/Goals.tsx
+++ b/src/pages/Goals.tsx
@@ -1,4 +1,49 @@
-import React from 'react'
-export default function PLACEHOLDER() {
-  return <div className="p-4 text-center">Página </div>
+import React, { useState } from 'react'
+import { useGoals, useCreateGoal, useUpdateGoal } from '../hooks/useGoals'
+import type { Goal } from '../types/goal'
+
+export default function Goals() {
+  const { data, isLoading, isError } = useGoals()
+  const createMutation = useCreateGoal()
+  const updateMutation = useUpdateGoal()
+  const goals: Goal[] = data?.data ?? []
+
+  const [form, setForm] = useState<Goal>({ id: 0, month: 1, year: new Date().getFullYear(), amount: 0 })
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: Number(e.target.value) })
+  }
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await createMutation.mutateAsync(form)
+    setForm({ id: 0, month: 1, year: new Date().getFullYear(), amount: 0 })
+  }
+
+  const handleUpdate = async (goal: Goal) => {
+    await updateMutation.mutateAsync({ id: goal.id, data: { amount: goal.amount } })
+  }
+
+  if (isLoading) return <div className="p-4">Cargando...</div>
+  if (isError) return <div className="p-4 text-red-500">Error al cargar</div>
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Metas de ahorro</h1>
+      <form onSubmit={submit} className="space-x-2">
+        <input type="number" name="year" value={form.year} onChange={handleChange} className="border p-1"/>
+        <input type="number" name="month" value={form.month} onChange={handleChange} className="border p-1"/>
+        <input type="number" name="amount" value={form.amount} onChange={handleChange} className="border p-1"/>
+        <button type="submit" className="bg-blue-500 text-white px-2 py-1">Crear</button>
+      </form>
+      <ul className="space-y-2">
+        {goals.map(g => (
+          <li key={g.id} className="flex items-center space-x-2">
+            <span>{g.year}-{g.month}</span>
+            <input type="number" value={g.amount} onChange={e => handleUpdate({ ...g, amount: Number(e.target.value) })} className="border p-1"/>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -6,8 +6,8 @@ import Login from '../pages/Auth/Login'
 import Register from '../pages/Auth/Register'
 import Dashboard from '../pages/Dashboard'
 import CategoryDetail from '../pages/CategoryDetail'
-import SearchExpenses from '../pages/SearchExpensesPlaceholder ' 
-import Goals from '../pages/GoalsPlaceholder' 
+import SearchExpenses from '../pages/SearchExpensesPlaceholder '
+import Goals from '../pages/Goals'
 
 // Componente Layout que incluye la Navbar
 const Layout: React.FC<{ children: React.ReactElement }> = ({ children }) => {


### PR DESCRIPTION
## Summary
- add hooks for expenses detail and goals
- implement category detail page to show expenses and allow deletion
- create goals page with list and creation form
- handle errors and validation in login and register
- use API client instance for expenses requests
- update routes and context

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6854e25b544c8330ac6dd33312028b5a