### PR TITLE
Fix API client usage

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,10 +1,7 @@
-import axios from 'axios'
+import { api } from './client'
 
-// const API_BASE_URL = 'http://198.211.105.95:8080';
-const API_BASE_URL = 'http://localhost:8000';
+export const login = (data: { email: string; passwd: string }) =>
+  api.post('/authentication/login', data)
 
-export const login = (data: { email: string, passwd: string }) =>
-  axios.post(API_BASE_URL+'/authentication/login', data)
-
-export const register = (data: { email: string, passwd: string }) =>
-  axios.post(API_BASE_URL+'/authentication/register', data)
+export const register = (data: { email: string; passwd: string }) =>
+  api.post('/authentication/register', data)

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
 
 const api = axios.create({
-  // baseURL: 'http://198.211.105.95:8080',
-  baseURL: 'http://localhost:8000',
+  // Fallback a localhost si no existe la variable de entorno
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000',
 })
 
 api.interceptors.request.use(config => {

--- a/src/api/goals.ts
+++ b/src/api/goals.ts
@@ -1,8 +1,8 @@
-import axios from 'axios';
+import { api } from './client'
 
-export const getGoals = () => axios.get('http://198.211.105.95:8080/goals');
+export const getGoals = () => api.get('/goals')
 
-export const createGoal = (data: any) => axios.post('http://198.211.105.95:8080/goals', data);
+export const createGoal = (data: any) => api.post('/goals', data)
 
 export const updateGoal = (id: number, data: any) =>
-    axios.patch(`http://198.211.105.95:8080/goals/${id}`, data);
+  api.patch(`/goals/${id}`, data)


### PR DESCRIPTION
## Summary
- fix API base URL and token interceptor
- use centralized API client for auth and goals

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.app.json` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6854e5728384833091ea8b72e6749afa